### PR TITLE
STS: Mark avatar support as recommended, but not mandatory

### DIFF
--- a/STS.md
+++ b/STS.md
@@ -119,6 +119,8 @@ Clients on operating systems where accessing the file system directly is difficu
 
 ##Avatars
 
+__Clients should offer support for avatars, but it is not mandatory.__
+
 Clients should allow user to have own avatar and see friend's avatars.
 
 Avatars are PNG images with a maximum size of (2^16) bytes, enforced by client.


### PR DESCRIPTION
Summary:

According to @tux3 and @dvor's suggestion, support for avatars should be
recommended, but not mandatory for Tox clients.

Arguments for:

* Avatars should be be an optional feature, since clients can be visually
  appealing without them

Arguments against:

* GUI clients without support for avatars might be a bad surprise for people

Status quo:

Currently it is not specified whether clietns have to have avatar support.


====
@dvor, @Impyy, @irungentoo, @tux3, @subliun