### PR TITLE
STS: Mark avatar support as recommended, but not mandatory, v2

### DIFF
--- a/STS.md
+++ b/STS.md
@@ -23,6 +23,7 @@ As Tox grows and more clients are created, we feel it is time to  create a Tox s
   * [User Profile Encryption](#user-profile-encryption)
   * [NoSpam Changing](#nospam-changing)
 5. [Avatars](#avatars)
+  * [No support for avatars](#no-avatars)
 6. User Discovery
   * [Tox URI Scheme](#tox-uri-scheme)
   * [DNS Discovery](#dns-discovery)
@@ -117,7 +118,12 @@ Clients should encourage good user habits:
 
 Clients on operating systems where accessing the file system directly is difficult should integrate with that OS's means of sharing files, by e.g. offering to attach a profile to an email (where warning 1 applies).
 
-##Avatars
+## Avatars
+
+__Clients should offer support for avatars, but it is not mandatory.__
+
+If your client does not have support for avatars, look [here](#no-avatars).
+
 
 Clients should allow user to have own avatar and see friend's avatars.
 
@@ -152,6 +158,12 @@ Elrond's avatar:    /home/gildor/.config/tox/avatars/43656C65627269616E20646F6E2
 Elladan's avatar:   /home/gildor/.config/tox/avatars/49486174655768656E48756D616E735468696E6B49416D4D7942726F74686572.png
 Elrohir's avatar    /home/gildor/.config/tox/avatars/726568746F7242794D6D41496B6E696854736E616D75486E6568576574614849.png
 ```
+
+<a name="no-avatars" />
+### No support for avatars
+
+In case where client doesn't support avatars, all file transfers ``TOX_FILE_KIND_AVATAR`` **must** be canceled.
+
 
 
 ##User Discovery


### PR DESCRIPTION
Summary:

According to @tux3 and @dvor's suggestion, support for avatars should be
recommended, but not mandatory for Tox clients.

As @GrayHatter requested, there is defined behaviour for clients that do not
support avatars.

Arguments for:

* Avatars should be an optional feature, since clients can be visually
  appealing without them
* There should be defined behaviour in case where client does not support
  avatars

Arguments against:

* GUI clients without support for avatars might be a bad surprise for people

Status quo:

Currently it is not specified whether clients have to have avatar support.

====
@dvor,  @GrayHatter, @Impyy, @tux3, @subliun

====
This PR might supersede #63, provided that there will be an agreement about it.
If this PR gets merged, #63 will be closed.