### PR TITLE
Change 'friend' to 'contact'

### DIFF
--- a/STS.md
+++ b/STS.md
@@ -6,8 +6,8 @@ As Tox grows and more clients are created, we feel it is time to  create a Tox s
 
 1. User Identification & Interaction
   * [User Identification](#user-identification--interaction)
-  * [Friend Requests](#friend-requests)
-  * [Friends List](#friends-list)
+  * [Contact Requests](#contact-requests)
+  * [Contacts List](#contacts-list)
   * [Group Messaging](#group-messaging)
   * [Multimedia Messaging](#multimedia-messaging)
   * [Emoticons](#emoticons)
@@ -32,21 +32,21 @@ As Tox grows and more clients are created, we feel it is time to  create a Tox s
 ##User Identification & Interaction
 ###The Tox ID
 - Users exchange a 76-character string containing hexadecimal representations of a public key, a nospam value, and a checksum to be used as an identifier. This is to be called the **Tox ID**.
-- Users may set a **Name** which offers a simpler means of identification once the friend request has been accepted. These names may be changed on-the-fly and do not alter the Tox ID in any way.
+- Users may set a **Name** which offers a simpler means of identification once the contact request has been accepted. These names may be changed on-the-fly and do not alter the Tox ID in any way.
 - Users may set a **Status**. The three statuses are **"Online, Away, and Busy"**.
 - Users may set a **Status message** , which is an arbitrary string of text that allows for updates about life activities, current willingness to converse, etc.
 
-###Friend Requests
+###Contact Requests
 There are three fields a Tox client must offer when a user goes to add another. While two of these fields are optional for the end-user to fill out, it is required that Tox clients provide all three fields in the UI. These are, and should be labeled as, as follows:
 
 | Type | Requirement | Description
 | --- | --- | ---
 | **Tox ID** | Required | The user can paste a Tox ID into the field, or, alternatively, if the user is on a mobile device, the option to use scan a QR code should also be offered
-| **Nickname** | Optional | The user can set a custom nickname for the friend they're about to add  
-| **Message** | Optional | The user can send a custom message to be displayed to the friend they're adding, either for identification purposes, or anything else.
+| **Nickname** | Optional | The user can set a custom nickname for the contact they're about to add  
+| **Message** | Optional | The user can send a custom message to be displayed to the contact they're adding, either for identification purposes, or anything else.
 
-###Friends List
-Each client should include a way to manage friend lists, including the ability to edit Nicknames, view last time a user has logged on, and perform various actions, such as friend deletion, etc.
+###Contacts List
+Each client should include a way to manage contact lists, including the ability to edit Nicknames, view last time a user has logged on, and perform various actions, such as contact deletion, etc.
 
 ###Group Messaging
 Tox allows for group messaging, where users may join a specified Tox ID and will be able to communicate in one "room". These are to be referred to as **Groupchats**. Clients will have a lot of leeway when it comes to the implementation of Groupchats, as each will offer a unique approach to it. However, they are a basic necessity and are required to be implemented, whatever the approach may be.
@@ -84,7 +84,7 @@ The path for Tox data on Windows is ``%APPDATA%/tox/`` (should this be roaming a
 
 The path for Tox data on Linux is ``~/.config/tox/`` 
 
-This was chosen to work with as many existing clients as possible while allowing users to switch clients easily without loosing friends and IDs.
+This was chosen to work with as many existing clients as possible while allowing users to switch clients easily without loosing contacts and IDs.
 
 
 ###Logging
@@ -97,16 +97,16 @@ This was chosen to work with as many existing clients as possible while allowing
 In order to prevent the threat of local data theft, all Tox clients should, however the method or implementation (including choice of crypto), provide a method to encrypt all local data. This is not STS-required, but heavily suggested in order to keep the users of Tox safe. (under discussion)
 
 ###NoSpam Changing
-All Tox IDs have attached a small NoSpam Key to prevent friend request spam. All clients should include a quick method of changing the NoSpam Key in the event of spam. This should never be done automatically, and should require an explicit action from the user. For more information on what the NoSpam Key is, and what it does, visit our [API Docs](https://libtoxcore.so)
+All Tox IDs have attached a small NoSpam Key to prevent contact request spam. All clients should include a quick method of changing the NoSpam Key in the event of spam. This should never be done automatically, and should require an explicit action from the user. For more information on what the NoSpam Key is, and what it does, visit our [API Docs](https://libtoxcore.so)
 
 
 ##User profiles
 
-The Tox ID and its associated friends list and save file is called a profile. Save files should use the ".tox" extension to denote that they are Tox save files; clients should recognize .tox save files, preferably via integration with the operating system. That way, merely by double clicking a .tox file, the client will import the file for use. Here, import means copy the file into the data directory (see "Tox data directory" below). When talking about a profile's name, we mean the base name of the file.
+The Tox ID and its associated contacts list and save file is called a profile. Save files should use the ".tox" extension to denote that they are Tox save files; clients should recognize .tox save files, preferably via integration with the operating system. That way, merely by double clicking a .tox file, the client will import the file for use. Here, import means copy the file into the data directory (see "Tox data directory" below). When talking about a profile's name, we mean the base name of the file.
 
 ###Profile management
 
-Clients should be able to track more than one Tox ID (i.e., its save file) in the same data directory. Clients should thus offer the ability to switch profiles (i.e., disconnect from the network, load a different profile, and reconnect), as well as import, rename, export, and delete profiles. These operations are relative to the data directory: importing means copying a file to the data directory, exporting means allowing the user to save a profile in a location of their choice, and deleting means removing the profile from the data directory. Together, these operations make it easy for a user to share a Tox ID and friend's list among whatever devices he or she uses.
+Clients should be able to track more than one Tox ID (i.e., its save file) in the same data directory. Clients should thus offer the ability to switch profiles (i.e., disconnect from the network, load a different profile, and reconnect), as well as import, rename, export, and delete profiles. These operations are relative to the data directory: importing means copying a file to the data directory, exporting means allowing the user to save a profile in a location of their choice, and deleting means removing the profile from the data directory. Together, these operations make it easy for a user to share a Tox ID and contact's list among whatever devices he or she uses.
 
 ###Recommendations regarding profile management
 
@@ -119,26 +119,26 @@ Clients on operating systems where accessing the file system directly is difficu
 
 ##Avatars
 
-Clients should allow user to have own avatar and see friend's avatars.
+Clients should allow user to have own avatar and see contact's avatars.
 
 Avatars are PNG images with a maximum size of (2^16) bytes, enforced by client.
 
-Avatars are sent as a file transfer with ``TOX_FILE_KIND_AVATAR``. Every time a friend goes offline you must send them a new avatar transfer. The ``file_id`` will be set to the hash of the avatar. If no avatar is set, the size of the avatar will be set to zero and the ``file_id`` will be set to ``NULL``. If the avatar transfer is cancelled by the friend, the other client must assume the friend already has the avatar and will not try to send it again, as long as friend will stay online. Upon friend going offline and back online, client must try to send avatar again.
+Avatars are sent as a file transfer with ``TOX_FILE_KIND_AVATAR``. Every time a contact goes offline you must send them a new avatar transfer. The ``file_id`` will be set to the hash of the avatar. If no avatar is set, the size of the avatar will be set to zero and the ``file_id`` will be set to ``NULL``. If the avatar transfer is cancelled by the contact, the other client must assume the contact already has the avatar and will not try to send it again, as long as contact will stay online. Upon contact going offline and back online, client must try to send avatar again.
 
-If the avatar is changed, a new avatar transfer must be started to all online friends.
+If the avatar is changed, a new avatar transfer must be started to all online contacts.
 
 When receiving a new file transfer with type ``TOX_FILE_KIND_AVATAR``:
 * check whether size is 0
-* if it is, cancel the file transfer and remove avatar of the friend if it was set
+* if it is, cancel the file transfer and remove avatar of the contact if it was set
 * if the size is non-zero:
-  - check whether hash of the current avatar of a friend matches the ``file_id`` for the incoming avatar transfer
+  - check whether hash of the current avatar of a contact matches the ``file_id`` for the incoming avatar transfer
   - if matches, the client will cancel the transfer
   - if it doesn't, the client will accept the file transfer
 
 
-It is desirable that the user avatar and the cached friends avatars could be shared among different Tox clients in the same system. This not only makes switching from one client to another easier, but also minimizes the need of data transfers, as avatars already downloaded by other clients can be reused.
+It is desirable that the user avatar and the cached contacts avatars could be shared among different Tox clients in the same system. This not only makes switching from one client to another easier, but also minimizes the need of data transfers, as avatars already downloaded by other clients can be reused.
 
-* Avatars are stored in a directory called ``avatars`` and named as ``xxxxx.png``, where ``xxxxx`` is the complete public key (but **not** friend address!), encoded as an uppercase hexadecimal string and ``png`` is the extension for the PNG avatar. As new image formats may be used in the future, clients should ensure that no other file ``xxxxx.*`` exists. No file should be kept for a user that has no avatar.
+* Avatars are stored in a directory called ``avatars`` and named as ``xxxxx.png``, where ``xxxxx`` is the complete public key (but **not** contact address!), encoded as an uppercase hexadecimal string and ``png`` is the extension for the PNG avatar. As new image formats may be used in the future, clients should ensure that no other file ``xxxxx.*`` exists. No file should be kept for a user that has no avatar.
 * The client's own avatar is not special and must be stored like any other. This is partially for simplicity, and partially in anticipation of profiles.
 * The avatar should be stored as it is received, without any modifications done by client for display purposes.
 


### PR DESCRIPTION
Changed all occurrences of the word 'friend' to the word 'contact', because it's more correct and neutral.

This pull request has already been discussed and accepted by voters, but due to an error in the commit description, it had to be updated. Original pull request can be seen here: https://github.com/Tox/Tox-STS/pull/61