### PR TITLE
Change / Proposal title

### DIFF
--- a/STS.md
+++ b/STS.md
@@ -81,11 +81,19 @@ If a user enters non-UTF-8 text, client should re-encode them as far as possible
 ##Client paths/formats
 ###Tox data directory
 
-The path for Tox data on Windows is ``%APPDATA%/tox/`` (should this be roaming app data?)
+The path for Tox data on Windows is ``%APPDATA%\tox\`` (should this be roaming app data?)
 
-The path for Tox data on Linux is ``~/.config/tox/`` 
+The path for Tox data on Linux is ``${XDG_CONFIG_HOME:-${HOME}/.config}/tox/``. This means:
+
+ 1. Look for the environment variable ``XDG_CONFIG_HOME``
+  1. If it exists and is not empty the environment variable's value should be considered to be the location of the user's configuration directory
+  2. If it does not exist or is empty a directory named ``.config`` in the user's home directory should be considered to be the user's configuration directory
+    * The user's home directory can either be determined using the mandatory ``HOME`` environment variable or by querying the user database using the ``getpwuid(getuid()).pw_dir`` call
+ 2. Within the user's configuration directory the ``tox`` subdirectory should then be used to store Tox-related files
 
 This was chosen to work with as many existing clients as possible while allowing users to switch clients easily without loosing friends and IDs.
+
+A client may never assume that any part of the Tox data directory path exists until it has created them.
 
 
 ###Logging


### PR DESCRIPTION
# 

**Summary:**

Require configuration directory to be determined based on XDG standards on Linux.

**Arguments for:**
- Consistent with most other newer Linux applications
- Already done by some Tox clients anyways
  - qTox does this already (since they rely on Qt's `QStandardPaths` class which already [does this for Linux](http://trac.netlabs.org/qt4/ticket/45))
  - gTox also does this already (since it uses [Glib::get_user_config_dir](https://developer.gnome.org/glib/unstable/glib-Miscellaneous-Utility-Functions.html#g-get-user-config-dir))
  - Toxic has implemented this voluntarily ([see the source code](https://github.com/JFreegman/toxic/blob/a920f3edfe9982c553dea8f21f374772f8cae882/src/configdir.c#L87))
- 100% backward-compatible change (since the default directory does not change)

**Arguments against:**

These are arguments against the proposal:
- It's a change...

**Status quo:**

Currently the specification mandates that Linux clients must use this directory: `~/.config/tox`

@tux3
@notsecure
@lehitoskin
@JFreegman
@JX7P
